### PR TITLE
Restate some navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { NativeBaseProvider, AddIcon, IconButton } from 'native-base';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
@@ -6,7 +7,7 @@ import auth from '@react-native-firebase/auth';
 
 import Authentication from './jin/screens/Authentication'
 import RestHome from './restaurant/RestHome.js';
-import DeliverScreen from './restaurant/DeliverScreen.js';
+import Chatroom from "./jin/screens/Chatroom.js";
 import ClientId from "./android/app/google-services.json"
 
 const BTab = createBottomTabNavigator();
@@ -51,11 +52,20 @@ export default function App() {
           <BTab.Screen
             name="식당리스트"
             component={RestHome}
-            options={{headerShown : false}} />
-          <BTab.Screen
-            name="같이배달"
-            component={DeliverScreen}
-            options={{headerShown : false}} />
+            options={{headerShown: false}} />
+          <BTab.Screen 
+                name="같이배달" 
+                component={Chatroom}
+                options={({ navigation }) => ({
+                    headerRight: () => (
+                        <NativeBaseProvider>
+                            <IconButton
+                                onPress={() => navigation.navigate('새로운 채팅방 만들기')}
+                                icon = {<AddIcon />} />
+                        </NativeBaseProvider>
+                    )
+                })
+               } />
         </BTab.Navigator>
       </NavigationContainer>
     );

--- a/App.js
+++ b/App.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { NativeBaseProvider, AddIcon, IconButton } from 'native-base';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
@@ -54,18 +53,9 @@ export default function App() {
             component={RestHome}
             options={{headerShown: false}} />
           <BTab.Screen 
-                name="같이배달" 
-                component={Chatroom}
-                options={({ navigation }) => ({
-                    headerRight: () => (
-                        <NativeBaseProvider>
-                            <IconButton
-                                onPress={() => navigation.navigate('새로운 채팅방 만들기')}
-                                icon = {<AddIcon />} />
-                        </NativeBaseProvider>
-                    )
-                })
-               } />
+              name="같이배달" 
+              component={Chatroom}
+              options={{headerShown: false}} />
         </BTab.Navigator>
       </NavigationContainer>
     );

--- a/jin/screens/Chatroom.js
+++ b/jin/screens/Chatroom.js
@@ -1,12 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Image, Button, ScrollView, TextInput, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Icon, Divider, NativeBaseProvider } from 'native-base';
-import Authentication from './Authentication';
 import auth, { firebase } from '@react-native-firebase/auth';
 import firestore from '@react-native-firebase/firestore';
 
-export default function Chatroom({ navigation }) {
+import Authentication from './Authentication';
+import CreateChat from "./CreateChat";
+import Chat from "./Chat";
+
+const Stack = createNativeStackNavigator();
+
+function Chatroom({ navigation }) {
     const [threads, setThreads] = useState([]);
     const [loading, setLoading] = useState(true);
 
@@ -63,6 +68,29 @@ export default function Chatroom({ navigation }) {
         </View>
         </NativeBaseProvider>
       );
+}
+
+export default function() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="같이 배달 리스트"
+        component={Chatroom}
+        options={{headerShown: false}} />
+      <Stack.Screen
+        name="새로운 채팅방 만들기"
+        component={CreateChat}
+        options={{headerShown: false}} />
+      <Stack.Screen 
+        name="메시지" 
+        component={Chat}
+        options={({ route }) => ({
+          headerShown: false,
+          title: route.params.thread.name  
+        })} 
+        />
+    </Stack.Navigator>
+  )
 }
 
 const styles = StyleSheet.create({

--- a/jin/screens/Chatroom.js
+++ b/jin/screens/Chatroom.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Image, Button, ScrollView, TextInput, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Icon, Divider, NativeBaseProvider } from 'native-base';
+import { AddIcon, IconButton, Divider, NativeBaseProvider } from 'native-base';
 import auth, { firebase } from '@react-native-firebase/auth';
 import firestore from '@react-native-firebase/firestore';
 
@@ -57,7 +57,7 @@ function Chatroom({ navigation }) {
                       <Text style={styles.nameText}>{item.name}</Text>
                     </View>
                     <Text style={styles.contentText}>
-                      {item.latestMessage.text.slice(0, 90)}
+                      {item.latestMessage.text != undefined && item.latestMessage.text.slice(0, 90)}
                     </Text>
                   </View>
                 </View>
@@ -70,26 +70,35 @@ function Chatroom({ navigation }) {
       );
 }
 
-export default function() {
+export default function({ navigation }) {
   return (
-    <Stack.Navigator>
-      <Stack.Screen
-        name="같이 배달 리스트"
-        component={Chatroom}
-        options={{headerShown: false}} />
-      <Stack.Screen
-        name="새로운 채팅방 만들기"
-        component={CreateChat}
-        options={{headerShown: false}} />
-      <Stack.Screen 
-        name="메시지" 
-        component={Chat}
-        options={({ route }) => ({
-          headerShown: false,
-          title: route.params.thread.name  
-        })} 
-        />
-    </Stack.Navigator>
+    <NativeBaseProvider>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="같이 배달 리스트"
+          component={Chatroom}
+          options={() => ({
+            title: "같이 배달",
+            headerRight: () => (
+              <IconButton
+                  onPress={() => navigation.navigate('새로운 채팅방 만들기')}
+                  icon = {<AddIcon />} />
+              )
+          })} />
+        <Stack.Screen
+          name="새로운 채팅방 만들기"
+          component={CreateChat}
+          options={{headerBackTitleVisible: false}} />
+        <Stack.Screen 
+          name="메시지" 
+          component={Chat}
+          options={({ route }) => ({
+            headerBackTitleVisible: false,
+            title: route.params.thread.name  
+          })} 
+          />
+      </Stack.Navigator>
+    </NativeBaseProvider>
   )
 }
 

--- a/restaurant/RestHome.js
+++ b/restaurant/RestHome.js
@@ -28,9 +28,6 @@ import RestInfo from './info/ListItem';
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import SearchInput, { createFilter } from 'react-native-search-filter';
 import Profile from "../jin/screens/Profile.js";
-import Chatroom from "../jin/screens/Chatroom.js";
-import CreateChat from "../jin/screens/CreateChat.js";
-import Chat from "../jin/screens/Chat.js";
 
 const KEYS_TO_FILTERS = ['name', 'dong', 'category'];
 
@@ -177,46 +174,15 @@ export default function App({ navigation }) {
                 options={{
                     headerLeft: () => (
                         <NativeBaseProvider>
-                            <TouchableOpacity style={{ marginLeft: 10, marginTop: 10, size: 10 }}
+                            <TouchableOpacity
                                 onPress={() => navigation.navigate('프로필')}>
                                     <HamburgerIcon />
-                            </TouchableOpacity>
-                        </NativeBaseProvider>
-                    ),
-                    headerRight: () => (
-                        <NativeBaseProvider>
-                            <TouchableOpacity style={{ marginRight: 10, marginTop: 10, size: 10 }}
-                                onPress={() => navigation.navigate('채팅')}>
-                                    <CircleIcon />
                             </TouchableOpacity>
                         </NativeBaseProvider>
                     )
                 }} />
             <Stack.Screen name="식당 정보" component={RestInfo} />
             <Stack.Screen name="프로필" component={Profile} />
-            <Stack.Screen 
-                name="채팅" 
-                component={Chatroom}
-                options={({ navigation }) => ({
-                    headerRight: () => (
-                        <NativeBaseProvider>
-                            <TouchableOpacity 
-                                style={{ marginRight: 10, marginTop: 10, size: 10 }}
-                                onPress={() => navigation.navigate('새로운 채팅방 만들기')}
-                            >
-                                <AddIcon />
-                            </TouchableOpacity>
-                        </NativeBaseProvider>
-                    )
-                })} />
-            <Stack.Screen name="새로운 채팅방 만들기" component={CreateChat} />
-            <Stack.Screen 
-                name="메시지" 
-                component={Chat}
-                options={({ route }) => ({
-                  title: route.params.thread.name  
-                })} 
-            />
         </Stack.Navigator>
     );
 }

--- a/restaurant/RestHome.js
+++ b/restaurant/RestHome.js
@@ -20,8 +20,7 @@ import {
     NativeBaseProvider,
     Select,
     CheckIcon,
-    CircleIcon,
-    AddIcon
+    IconButton
 } from "native-base";
 import database from '@react-native-firebase/database';
 import RestInfo from './info/ListItem';
@@ -169,21 +168,20 @@ const Stack = createNativeStackNavigator();
 
 export default function App({ navigation }) {
     return (
-        <Stack.Navigator>
-            <Stack.Screen name="식당 리스트" component={Home}
-                options={{
-                    headerLeft: () => (
-                        <NativeBaseProvider>
-                            <TouchableOpacity
-                                onPress={() => navigation.navigate('프로필')}>
-                                    <HamburgerIcon />
-                            </TouchableOpacity>
-                        </NativeBaseProvider>
-                    )
-                }} />
-            <Stack.Screen name="식당 정보" component={RestInfo} />
-            <Stack.Screen name="프로필" component={Profile} />
-        </Stack.Navigator>
+        <NativeBaseProvider>
+            <Stack.Navigator>
+                <Stack.Screen name="식당 리스트" component={Home}
+                    options={{
+                        headerLeft: () => (
+                            <IconButton
+                                onPress={() => navigation.navigate('프로필')}
+                                icon = {<HamburgerIcon />} />
+                        )
+                    }} />
+                <Stack.Screen name="식당 정보" component={RestInfo} />
+                <Stack.Screen name="프로필" component={Profile} />
+            </Stack.Navigator>
+        </NativeBaseProvider>
     );
 }
 


### PR DESCRIPTION
- 채팅 위치를 같이 배달로 이동
- NativeBaseProvider가 navigator의 헤더 안에 있을 경우 글씨가 밀려나는 오류 해결
- 같이 배달의 navigator 활성화
- 같이 배달 리스트의 list item이 undefined일 경우 발생하는 버그 해결
---
- Move chat function location to 같이 배달
- Fixed an error that letters was pushed out of screen if NativeBaseProvider was in the navigator's header
- Activate 같이 배달 navigator header
- Fixed bugs that occur when the list item of chat list is undefined