### PR TITLE
리스트 아이템 화면 개선

### DIFF
--- a/restaurant/RestHome.js
+++ b/restaurant/RestHome.js
@@ -269,18 +269,10 @@ export default function App({ navigation }) {
         <Stack.Screen
           name="식당 정보"
           component={RestInfo}
-          options={({ route }) => ({
-            headerTitle: () => (
-              <Text style={styles.headerTitle}>{route.params.title}</Text>
-            ),
-            headerBackTitleVisible: false,
-            headerStyle: {
-              backgroundColor: '#BF2A52',
-            },
-            headerTintColor: '#fff',
-            headerTitleAlign: 'center',
+          options={{
+            headerShown: false,
             animation: 'fade_from_bottom'
-          })}
+          }}
         />
         <Stack.Screen
           name="앱정보"

--- a/restaurant/info/InfoElements.js
+++ b/restaurant/info/InfoElements.js
@@ -63,8 +63,12 @@ const CommentListView = (props) => {
     } else if (writtenDate.includes('오후')) {
       writtenDate = writtenDate.replace('. 오후 ', ' ').replace(/\. /g, '/');
       const hourIndex = writtenDate.indexOf(':');
-      const writtenHour = parseInt(writtenDate.substring(hourIndex - 2, hourIndex));
-      writtenDate = writtenDate.substring(0, hourIndex - 2) + (writtenHour + 12) + writtenDate.substring(hourIndex);
+      let hourDigit = 2;
+      if (writtenDate[hourIndex - hourDigit] == ' ') {
+        hourDigit = 1;
+      }
+      const writtenHour = parseInt(writtenDate.substring(hourIndex - hourDigit, hourIndex));
+      writtenDate = writtenDate.substring(0, hourIndex - hourDigit) + (writtenHour + 12) + writtenDate.substring(hourIndex);
     }
 
     const date = new Date(writtenDate);

--- a/restaurant/info/ListItem.js
+++ b/restaurant/info/ListItem.js
@@ -53,7 +53,6 @@ const RestComponent = (props) => {
   const toast = useToast();
   const user = auth().currentUser;
   const restData = props.restData;
-  console.log(restData)
   const menuList = restData['menu'];
   const commentsList = restData['comments'];
   let menu = [];
@@ -419,7 +418,7 @@ const RestaurantInfo = (props) => {
   )
 }
 
-const ItemActivity = ({ route }) => {
+const ItemActivity = ({ navigation, route }) => {
   const RestInfo = () => {
     return <RestaurantInfo restId={route.params.restId} />;
   }
@@ -441,6 +440,14 @@ const ItemActivity = ({ route }) => {
             },
             headerTintColor: '#fff',
             headerTitleAlign: 'center',
+            headerLeft: () => (
+              <Font
+                name="align-left"
+                size={24}
+                color="#fff"
+                onPress={navigation.goBack}
+              />
+            )
           }}
         />
         <Stack.Screen

--- a/restaurant/info/ListItem.js
+++ b/restaurant/info/ListItem.js
@@ -16,6 +16,7 @@ import KakaoShareLink from 'react-native-kakao-share-link';
 
 import CommentButton from './CommentModal';
 import MapScreen from './MapScreen';
+import RouteWebScreen from './RouteWebScreen';
 import { KeyTextView, InfoView, MenuListView, CommentListView, RatingBar, InfoModal } from './InfoElements';
 
 const Stack = createNativeStackNavigator();
@@ -456,6 +457,30 @@ const ItemActivity = ({ navigation, route }) => {
           options={{
             headerTitle: () => (
               <Text style={style.headerTitle}>{route.params.title} 위치</Text>
+            ),
+            headerBackTitleVisible: false,
+            headerStyle: {
+              backgroundColor: '#BF2A52',
+            },
+            headerTintColor: '#fff',
+            headerTitleAlign: 'center',
+            headerRight: () => (
+              <Font
+                name="map-marker"
+                size={24}
+                color="#fff"
+                onPress={() => navigation.navigate('식당 길찾기')}
+              />
+            ),
+            animation: 'slide_from_right'
+          }}
+        />
+        <Stack.Screen
+          name="식당 길찾기"
+          component={RouteWebScreen}
+          options={{
+            headerTitle: () => (
+              <Text style={style.headerTitle}>{route.params.title} 길찾기</Text>
             ),
             headerBackTitleVisible: false,
             headerStyle: {

--- a/restaurant/info/ListItem.js
+++ b/restaurant/info/ListItem.js
@@ -53,6 +53,7 @@ const RestComponent = (props) => {
   const toast = useToast();
   const user = auth().currentUser;
   const restData = props.restData;
+  console.log(restData)
   const menuList = restData['menu'];
   const commentsList = restData['comments'];
   let menu = [];
@@ -429,12 +430,34 @@ const ItemActivity = ({ route }) => {
         <Stack.Screen
           name="식당 정보 화면"
           component={RestInfo}
-          options={{ headerShown: false }}
+          initialParams={route.params}
+          options={{
+            headerTitle: () => (
+              <Text style={style.headerTitle}>{route.params.title}</Text>
+            ),
+            headerBackTitleVisible: false,
+            headerStyle: {
+              backgroundColor: '#BF2A52',
+            },
+            headerTintColor: '#fff',
+            headerTitleAlign: 'center',
+          }}
         />
         <Stack.Screen
           name="식당 위치"
           component={MapScreen}
-          options={{ headerShown: false }}
+          options={{
+            headerTitle: () => (
+              <Text style={style.headerTitle}>{route.params.title} 위치</Text>
+            ),
+            headerBackTitleVisible: false,
+            headerStyle: {
+              backgroundColor: '#BF2A52',
+            },
+            headerTintColor: '#fff',
+            headerTitleAlign: 'center',
+            animation: 'slide_from_right'
+          }}
         />
       </Stack.Navigator>
     </NativeBaseProvider>
@@ -444,6 +467,11 @@ const ItemActivity = ({ route }) => {
 export default ItemActivity;
 
 const style = StyleSheet.create({
+  headerTitle: {
+    fontSize: 20,
+    color: '#f5f5f5',
+    fontFamily: 'ELANDChoiceB'
+  },
   containter: {
     height: '100%',
     backgroundColor: '#f5f5f5'

--- a/restaurant/info/ListItem.js
+++ b/restaurant/info/ListItem.js
@@ -469,7 +469,7 @@ const ItemActivity = ({ navigation, route }) => {
                 name="map-marker"
                 size={24}
                 color="#fff"
-                onPress={() => navigation.navigate('식당 길찾기', { name: route.params.name, coordinate: route.params.coordinate })}
+                onPress={() => navigation.navigate('식당 길찾기', { name: route.params.name, coordinate: route.params.coordinate, myPosition: route.params.myPosition })}
               />
             ),
             animation: 'slide_from_right'

--- a/restaurant/info/ListItem.js
+++ b/restaurant/info/ListItem.js
@@ -454,9 +454,9 @@ const ItemActivity = ({ navigation, route }) => {
         <Stack.Screen
           name="식당 위치"
           component={MapScreen}
-          options={{
+          options={({ route }) => ({
             headerTitle: () => (
-              <Text style={style.headerTitle}>{route.params.title} 위치</Text>
+              <Text style={style.headerTitle}>{route.params.name} 위치</Text>
             ),
             headerBackTitleVisible: false,
             headerStyle: {
@@ -469,11 +469,11 @@ const ItemActivity = ({ navigation, route }) => {
                 name="map-marker"
                 size={24}
                 color="#fff"
-                onPress={() => navigation.navigate('식당 길찾기')}
+                onPress={() => navigation.navigate('식당 길찾기', { name: route.params.name, coordinate: route.params.coordinate })}
               />
             ),
             animation: 'slide_from_right'
-          }}
+          })}
         />
         <Stack.Screen
           name="식당 길찾기"

--- a/restaurant/info/MapScreen.js
+++ b/restaurant/info/MapScreen.js
@@ -3,7 +3,7 @@ import { StyleSheet, Platform, Dimensions } from 'react-native';
 import NaverMapView, { Marker } from 'react-native-nmap';
 import Geolocation from 'react-native-geolocation-service';
 
-const MapScreen = ({ route }) => {
+const MapScreen = ({ navigation, route }) => {
   const [currentPosition, setPosition] = useState({ latitude: 36.103116, longitude: 129.388368 }); // Handong University
   const [centerPosition, setCenter] = useState(route.params.coordinate)
   const [zoomLevel, setZoom] = useState(16)
@@ -34,6 +34,8 @@ const MapScreen = ({ route }) => {
       console.log(error.code, error.message);
     }, { enableHighAccuracy: true, timeout: 15000, maximumAge: 10000 }
     )
+
+    navigation.setParams({ myPosition: { latitude: currentPosition.latitude, longitude: currentPosition.longitude }, ...route.params});
   }, [zoomLevel]);
 
   return (

--- a/restaurant/info/MapScreen.js
+++ b/restaurant/info/MapScreen.js
@@ -2,10 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { StyleSheet, Platform, Dimensions } from 'react-native';
 import NaverMapView, { Marker } from 'react-native-nmap';
 import Geolocation from 'react-native-geolocation-service';
-import { useNavigation } from '@react-navigation/native';
 
 const MapScreen = ({ route }) => {
-  const navigation = useNavigation();
   const [currentPosition, setPosition] = useState({ latitude: 36.103116, longitude: 129.388368 }); // Handong University
   const [centerPosition, setCenter] = useState(route.params.coordinate)
   const [zoomLevel, setZoom] = useState(16)
@@ -48,7 +46,6 @@ const MapScreen = ({ route }) => {
       zoomControl={false}
       minZoomLevel={6}
       maxZoomLevel={19}
-      onMapClick={() => navigation.goBack()}
     >
       <Marker
         coordinate={currentPosition}

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -2,10 +2,11 @@ import React from 'react';
 import WebView from 'react-native-webview';
 
 const RouteWebScreen = ({ route }) => {
-  console.log(route.params)
+  const {name, coordinate} = route.params;
+  const restPath = `https://m.map.naver.com/route.nhn?menu=route&ename=${'가온밀면'}&ex=${coordinate.latitude}&ey=${coordinate.longitude}&pathType=0&showMap=true`;
   return (
     <WebView
-      source={{ uri: 'https://www.google.com' }}
+      source={{ uri: restPath }}
     />
   )
 }

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -4,7 +4,7 @@ import WebView from 'react-native-webview';
 const RouteWebScreen = ({ route }) => {
   console.log(route.params)
   const {name, coordinate, myPosition} = route.params;
-  const restPath = `https://m.map.naver.com/route.nhn?menu=route&sname=내 위치&sx=${myPosition.latitude}&sy=${myPosition.longitude}&ename=${name}&ex=${coordinate.latitude}&ey=${coordinate.longitude}&pathType=0&showMap=true`;
+  const restPath = `https://m.map.naver.com/route.nhn?menu=route&sname=내 위치&sx=${myPosition.longitude}&sy=${myPosition.latitude}&ename=${name}&ex=${coordinate.longitude}&ey=${coordinate.latitude}&pathType=0&showMap=true`;
   console.log(restPath)
   return (
     <WebView

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import WebView from 'react-native-webview';
+
+const RouteWebScreen = () => {
+  return (
+    <WebView
+      
+    />
+  )
+}
+
+export default RouteWebScreen;

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import WebView from 'react-native-webview';
 
-const RouteWebScreen = () => {
+const RouteWebScreen = ({ route }) => {
+  console.log(route.params)
   return (
     <WebView
-      
+      source={{ uri: 'https://www.google.com' }}
     />
   )
 }

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -2,8 +2,10 @@ import React from 'react';
 import WebView from 'react-native-webview';
 
 const RouteWebScreen = ({ route }) => {
-  const {name, coordinate} = route.params;
-  const restPath = `https://m.map.naver.com/route.nhn?menu=route&ename=${'가온밀면'}&ex=${coordinate.latitude}&ey=${coordinate.longitude}&pathType=0&showMap=true`;
+  console.log(route.params)
+  const {name, coordinate, myPosition} = route.params;
+  const restPath = `https://m.map.naver.com/route.nhn?menu=route&sname=내 위치&sx=${myPosition.latitude}&sy=${myPosition.longitude}&ename=${name}&ex=${coordinate.latitude}&ey=${coordinate.longitude}&pathType=0&showMap=true`;
+  console.log(restPath)
   return (
     <WebView
       source={{ uri: restPath }}

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -2,12 +2,11 @@ import React from 'react';
 import WebView from 'react-native-webview';
 
 const RouteWebScreen = ({ route }) => {
-  console.log(route.params)
-  const {name, coordinate, myPosition} = route.params;
+  const { name, coordinate, myPosition } = route.params;
   const restPath = `https://m.map.naver.com/route.nhn?menu=route&sname=내 위치&sx=${myPosition.longitude}&sy=${myPosition.latitude}&ename=${name}&ex=${coordinate.longitude}&ey=${coordinate.latitude}&pathType=1&showMap=true`;
-  console.log(restPath)
   return (
     <WebView
+      onShouldStartLoadWithRequest={() => true}
       source={{ uri: restPath }}
     />
   )

--- a/restaurant/info/RouteWebScreen.js
+++ b/restaurant/info/RouteWebScreen.js
@@ -4,7 +4,7 @@ import WebView from 'react-native-webview';
 const RouteWebScreen = ({ route }) => {
   console.log(route.params)
   const {name, coordinate, myPosition} = route.params;
-  const restPath = `https://m.map.naver.com/route.nhn?menu=route&sname=내 위치&sx=${myPosition.longitude}&sy=${myPosition.latitude}&ename=${name}&ex=${coordinate.longitude}&ey=${coordinate.latitude}&pathType=0&showMap=true`;
+  const restPath = `https://m.map.naver.com/route.nhn?menu=route&sname=내 위치&sx=${myPosition.longitude}&sy=${myPosition.latitude}&ename=${name}&ex=${coordinate.longitude}&ey=${coordinate.latitude}&pathType=1&showMap=true`;
   console.log(restPath)
   return (
     <WebView


### PR DESCRIPTION
변경사항
===
- 리스트 아이템의 header를 리스트의 navigator의 header에서 리스트 아이템의 header로 변경
  - **기존** : RestHome.js의 header를 사용
  - **현재** : ListItem.js의 header를 사용
  - 이제 전체 화면 지도 창에서 뒤로가기를 누르면 식당 리스트 화면이 아닌, 식당 리스트 정보 화면으로 돌아감
- 전체 화면 지도에서 지도를 누르면 해당 탭에서 나가지는 기능 삭제
- 리스트 아이템과 전체 화면 지도에 각각의 고유 header를 사용하도록 변경
- 길찾기 기능 추가
  - 네이버 길찾기 URL scheme을 이용하여 자동으로 해당 위치까지의 대중교통 동선을 출력
  - 대신 네이버 창 자체로 출력되기 떄문에, 기능을 한정시키고 싶다면 view를 수정해야 함

수정 사항
---
- iOS에서 시간이 한 자리수(0-9)일 경우 인덱스를 잘못 지정하는 오류 수정